### PR TITLE
Fix repo button target

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -45,13 +45,13 @@ sphinx:
     - sphinx_multitoc_numbering
   config:
     bibtex_reference_style: author_year
-    nb_execution_raise_on_error: true 
+    nb_execution_raise_on_error: true
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/executablebooks/jupyter-book  # Online location of your book
-  path_to_book: docs  # Optional path to your book, relative to the repository root
-  branch: master  # Which branch of the repository should be used when creating links (optional)
+  url: https://github.com/kgoebber/metpy_thebook  # Online location of your book
+  # path_to_book: docs  # Optional path to your book, relative to the repository root
+  branch: main  # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository


### PR DESCRIPTION
Hello! I saw your talk at AMS today.

Currently, when you click on the repo button from the generated website, it links to the github for the [executable book project](https://github.com/executablebooks/jupyter-book)

<img width="1418" alt="textbook website home page, see hover link to the executable book project" src="https://github.com/kgoebber/metpy_thebook/assets/38434768/6b5840b1-4563-4caa-97df-53fd482a1f17">


This PR updates that location in _config.yml to https://github.com/kgoebber/metpy_thebook. See this local generation, with an updated link preview:

<img width="1309" alt="local generation of webpage, with link preview pointing to this repo" src="https://github.com/kgoebber/metpy_thebook/assets/38434768/b1554e8d-e1b5-4d33-a48c-81fe9f81dfe7">
